### PR TITLE
Switch to using innerText instead of innerHTML to display greeting

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -26,7 +26,7 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    response.setContentType("text/html;");
-    response.getWriter().println("<h3>Hello Fatima!</h3>");
+    response.setContentType("text;");
+    response.getWriter().println("Hello Fatima!");
   }
 }

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -28,7 +28,7 @@
 
         <h2>Greetings</h2>
         <p>Click here to see a greeting:</p>
-        <button onclick="getGreetingUsingAsyncAwait() ">Fetch a greeting!</button>
+        <button onclick="getGreetingUsingAsyncAwait()">Fetch a greeting!</button>
         <div id="greeting-container"></div>
     </div>
   </body>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -29,7 +29,7 @@ function addRandomFact() {
   factContainer.style.color = "#023C40";
   factContainer.innerText = fact;
   factContainer.innerText.style.color = "#FEE9E1";
-  factContainer.innerText.style.font = "20px georgia";
+  factContainer.innerText.style.font = "12px georgia";
 }
 
 
@@ -42,5 +42,6 @@ async function getGreetingUsingAsyncAwait() {
   const greetingContainer = document.getElementById('greeting-container');
   greetingContainer.innerText = greeting;
   greetingContainer.innerText.style.color = "#FEE9E1";
-  greetingContainer.innerText.style.font = "20px georgia";
+  greetingContainer.innerText.style.font = "12px georgia";
+  greetingContainer.innerText.padding = "10px";
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -39,5 +39,5 @@ function addRandomFact() {
 async function getGreetingUsingAsyncAwait() { 
   const response = await fetch('/data');
   const greeting = await response.text();
-  document.getElementById('greeting-container').innerHTML = greeting;
+  document.getElementById('greeting-container').innerText = greeting;
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -39,5 +39,8 @@ function addRandomFact() {
 async function getGreetingUsingAsyncAwait() { 
   const response = await fetch('/data');
   const greeting = await response.text();
-  document.getElementById('greeting-container').innerText = greeting;
+  const greetingContainer = document.getElementById('greeting-container');
+  greetingContainer.innerText = greeting;
+  greetingContainer.innerText.style.color = "#FEE9E1";
+  greetingContainer.innerText.style.font = "20px georgia";
 }


### PR DESCRIPTION
- Prevent a cross-site scripting (XSS) attack by setting innerText of greeting-container and formatting the HTML element using JavaScript instead of an HTML response