### PR TITLE
Add tests to support optional meeting attendees

### DIFF
--- a/walkthroughs/week-5-tdd/intro/src/main/java/com/google/sps/Greeter.java
+++ b/walkthroughs/week-5-tdd/intro/src/main/java/com/google/sps/Greeter.java
@@ -22,6 +22,7 @@ public class Greeter {
    * Returns a greeting for the given name.
    */
   public String greet(String name) {
-    return "Hello " + name;
+    
+    return "Hello " + name.trim().replaceAll("[^a-zA-Z0-9]", "");
   }
 }

--- a/walkthroughs/week-5-tdd/intro/src/test/java/com/google/sps/GreeterTest.java
+++ b/walkthroughs/week-5-tdd/intro/src/test/java/com/google/sps/GreeterTest.java
@@ -26,7 +26,7 @@ public final class GreeterTest {
   public void testGreeting() {
     Greeter greeter = new Greeter();
 
-    String greeting = greeter.greet("Ada");
+    String greeting = greeter.greet("@#Ada@#");
 
     Assert.assertEquals("Hello Ada", greeting);
   }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -46,7 +46,20 @@ public final class FindMeetingQuery {
    * @param attendees The collection of people attending the event. Must be non-null.
    */
    private ArrayList<TimeRange> findEventTimes(Collection<Event> events, MeetingRequest request) {
+       ArrayList<TimeRange> times = new ArrayList<TimeRange>();
+        for (Event event : events) {
+            HashSet<String> commonAttendees = new HashSet<String>();
 
+            // Add the event attendees first because there tends to be fewer of them
+            commonAttendees.addAll(event.getAttendees()); 
+            // Ensure to only find availability of the requested attendees
+            commonAttendees.retainAll(request.getAttendees()); 
+
+            if (commonAttendees.size() > 0) { 
+                times.add(event.getWhen());
+            }
+
+        return times;
    }
 
   /**

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -29,28 +29,25 @@ public final class FindMeetingQuery {
   /**
    * Return time ranges when an event can be scheduled for all mandatory attendes of the meeting request.
    *
-   * @param title The human-readable name for the event. Must be non-null.
-   * @param when The time when the event takes place. Must be non-null.
-   * @param attendees The collection of people attending the event. Must be non-null.
+   * @param events The complete collection of events in the booking system.
+   * @param request The specific meeting request that the user is making.
+   * @return The list of available event times.
    */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-
-    // The meeting duration can not be longer than an entire day
-    //TimeRange.WHOLE_DAY
     
     ArrayList<TimeRange> mandatoryAttendeeEventTimes = findEventTimes(events, request);
     LinkedList<TimeRange> unavailableTimes = determineUnavailableTimes(mandatoryAttendeeEventTimes);
     
-    return determineAvailableTimes(unavailableTimes, request);
+    return determineAvailableTimes(unavailableTimes, request.getDuration());
 
   }
 
   /**
-   * Find all events that will be attended by any mandatory attendee of the request.
+   * Find all events that will be attended by attendees of the meeting request.
    *
-   * @param title The human-readable name for the event. Must be non-null.
-   * @param when The time when the event takes place. Must be non-null.
-   * @param attendees The collection of people attending the event. Must be non-null.
+   * @param events The complete collection of events in the booking system.
+   * @param request The specific meeting request that the user is making.
+   * @return The list of all event times attended by the required attendees.
    */
    private ArrayList<TimeRange> findEventTimes(Collection<Event> events, MeetingRequest request) {
        ArrayList<TimeRange> times = new ArrayList<TimeRange>();
@@ -73,9 +70,8 @@ public final class FindMeetingQuery {
   /**
    * Determine the overlap among all event times, using an O(nlogn) sorting algorithm and an O(n) linear pass to merge the TimeRanges.
    *
-   * @param title The human-readable name for the event. Must be non-null.
-   * @param when The time when the event takes place. Must be non-null.
-   * @param attendees The collection of people attending the event. Must be non-null.
+   * @param eventTimes The list of all event times attended by the required attendees.
+   * @return The list of attendee event time overlaps.
    */
    private LinkedList<TimeRange> determineUnavailableTimes(ArrayList<TimeRange> eventTimes) {
 
@@ -89,7 +85,7 @@ public final class FindMeetingQuery {
                mergedeventTimes.add(tr);
            }
 
-           // Merge current and previous TimeRange if overlap exists by updating the last TimeRange -- can we always be sure last time?
+           // Merge current and previous TimeRange if overlap exists by updating the last TimeRange 
            else {
                TimeRange lastTime = mergedeventTimes.getLast();
 
@@ -113,14 +109,13 @@ public final class FindMeetingQuery {
   /**
    * Find the time in each day outside of the range of unavailable times.
    *
-   * @param title The human-readable name for the event. Must be non-null.
-   * @param when The time when the event takes place. Must be non-null.
-   * @param attendees The collection of people attending the event. Must be non-null.
+   * @param unavailableTimes The list of attendee event time overlaps.
+   * @param requestDuration The duration of the requested meeting: all meeting times must be longer than this
+   * @return The complete list of available times for the requested meeting to occur.  
    */
-    private ArrayList<TimeRange> determineAvailableTimes(LinkedList<TimeRange> unavailableTimes, MeetingRequest request) {
+    private ArrayList<TimeRange> determineAvailableTimes(LinkedList<TimeRange> unavailableTimes, long requestDuration) {
 
         ArrayList<TimeRange> availableTimes = new ArrayList<TimeRange>();
-        long requestDuration = request.getDuration();
 
         // If no time conflicts are found, or there are no attendees present in the meeting request, and the meeting request is shorter than a whole day
         if (unavailableTimes.size() == 0) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -15,9 +15,56 @@
 package com.google.sps;
 
 import java.util.Collection;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Comparator;
+import java.util.Collections;
 
 public final class FindMeetingQuery {
+  /**
+   * Return time ranges when an event can be scheduled for all mandatory attendes of the meeting request.
+   *
+   * @param title The human-readable name for the event. Must be non-null.
+   * @param when The time when the event takes place. Must be non-null.
+   * @param attendees The collection of people attending the event. Must be non-null.
+   */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     throw new UnsupportedOperationException("TODO: Implement this method.");
   }
+
+  /**
+   * Find all events that will be attended by any mandatory attendee of the request.
+   *
+   * @param title The human-readable name for the event. Must be non-null.
+   * @param when The time when the event takes place. Must be non-null.
+   * @param attendees The collection of people attending the event. Must be non-null.
+   */
+   private Collection<TimeRange> findEvents(Collection<Event> events, MeetingRequest request, QueryType type) {
+
+   }
+
+  /**
+   * Determine the overlap between all event times. 
+   *
+   * @param title The human-readable name for the event. Must be non-null.
+   * @param when The time when the event takes place. Must be non-null.
+   * @param attendees The collection of people attending the event. Must be non-null.
+   */
+   private Collection<TimeRange> determineUnavailableTimes(Collection<Event> events, MeetingRequest request, QueryType type) {
+
+   }
+
+  /**
+   * Find the time in each day outside of the range of unavailable times.
+   *
+   * @param title The human-readable name for the event. Must be non-null.
+   * @param when The time when the event takes place. Must be non-null.
+   * @param attendees The collection of people attending the event. Must be non-null.
+   */
+   private Collection<TimeRange> determineAvailableTimes(Collection<Event> events, MeetingRequest request, QueryType type) {
+
+   }
+      
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Comparator;
 import java.util.Collections;
+import java.util.LinkedList;
 
 public final class FindMeetingQuery {
   /**
@@ -33,8 +34,9 @@ public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
 
     ArrayList<TimeRange> mandatoryAttendeeEventTimes = findEventTimes(events, request);
-    ArrayList<TimeRange> unavailableTimes = determineUnavailableTimes(mandatoryAttendeeEventTimes);
-    ArrayList<TimeRange> availableTimes = determineAvailableTimes(unavailableTimes);
+    LinkedList<TimeRange> unavailableTimes = determineUnavailableTimes(mandatoryAttendeeEventTimes);
+    //ArrayList<TimeRange> availableTimes = determineAvailableTimes(unavailableTimes);
+    return unavailableTimes;
 
   }
 
@@ -58,19 +60,49 @@ public final class FindMeetingQuery {
             if (commonAttendees.size() > 0) { 
                 times.add(event.getWhen());
             }
+        }
 
         return times;
    }
 
   /**
-   * Determine the overlap among all event times. 
+   * Determine the overlap among all event times, using an O(nlogn) sorting algorithm and an O(n) linear pass to merge the TimeRanges.
    *
    * @param title The human-readable name for the event. Must be non-null.
    * @param when The time when the event takes place. Must be non-null.
    * @param attendees The collection of people attending the event. Must be non-null.
    */
-   private ArrayList<TimeRange> determineUnavailableTimes(ArrayList<TimeRange> eventTimes) {
+   private LinkedList<TimeRange> determineUnavailableTimes(ArrayList<TimeRange> eventTimes) {
 
+       // Sort the times to reduce time complexity by allowing us to identify overlap quicker
+       eventTimes.sort(TimeRange.ORDER_BY_START);
+
+       LinkedList<TimeRange> mergedeventTimes = new LinkedList<>();
+       for (TimeRange tr : mergedeventTimes) {
+           // Append current TimeRange if there's no overlap with the last TimeRange or no TimeRanges have been merged yet
+           if (mergedeventTimes.isEmpty() || mergedeventTimes.getLast().overlaps(tr)) {
+               mergedeventTimes.add(tr);
+           }
+
+           // Merge current and previous TimeRange if overlap exists by updating the last TimeRange
+           else {
+               TimeRange lastTime = mergedeventTimes.getLast();
+
+               // Identify the latest end of the merged Time Range
+               int mergedEnd; 
+               if (Long.compare(lastTime.end(), tr.end()) > 0) {
+                   mergedEnd = lastTime.end();
+               }
+               else {
+                   mergedEnd = tr.end();
+               }
+
+               //mergedeventTimes.getLast()
+               lastTime = TimeRange.fromStartEnd(lastTime.start(),mergedEnd, false);
+           }
+        }
+
+        return mergedeventTimes;
    }
 
   /**
@@ -80,8 +112,8 @@ public final class FindMeetingQuery {
    * @param when The time when the event takes place. Must be non-null.
    * @param attendees The collection of people attending the event. Must be non-null.
    */
-   private ArrayList<TimeRange> determineAvailableTimes(ArrayList<TimeRange> unavailableTimes) {
+//    private ArrayList<TimeRange> determineAvailableTimes(LinkedList<TimeRange> unavailableTimes) {
 
-   }
+//    }
       
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -31,7 +31,11 @@ public final class FindMeetingQuery {
    * @param attendees The collection of people attending the event. Must be non-null.
    */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+
+    ArrayList<TimeRange> mandatoryAttendeeEventTimes = findEventTimes(events, request);
+    ArrayList<TimeRange> unavailableTimes = determineUnavailableTimes(mandatoryAttendeeEventTimes);
+    ArrayList<TimeRange> availableTimes = determineAvailableTimes(unavailableTimes);
+
   }
 
   /**
@@ -41,18 +45,18 @@ public final class FindMeetingQuery {
    * @param when The time when the event takes place. Must be non-null.
    * @param attendees The collection of people attending the event. Must be non-null.
    */
-   private Collection<TimeRange> findEvents(Collection<Event> events, MeetingRequest request, QueryType type) {
+   private ArrayList<TimeRange> findEventTimes(Collection<Event> events, MeetingRequest request) {
 
    }
 
   /**
-   * Determine the overlap between all event times. 
+   * Determine the overlap among all event times. 
    *
    * @param title The human-readable name for the event. Must be non-null.
    * @param when The time when the event takes place. Must be non-null.
    * @param attendees The collection of people attending the event. Must be non-null.
    */
-   private Collection<TimeRange> determineUnavailableTimes(Collection<Event> events, MeetingRequest request, QueryType type) {
+   private ArrayList<TimeRange> determineUnavailableTimes(ArrayList<TimeRange> eventTimes) {
 
    }
 
@@ -63,7 +67,7 @@ public final class FindMeetingQuery {
    * @param when The time when the event takes place. Must be non-null.
    * @param attendees The collection of people attending the event. Must be non-null.
    */
-   private Collection<TimeRange> determineAvailableTimes(Collection<Event> events, MeetingRequest request, QueryType type) {
+   private ArrayList<TimeRange> determineAvailableTimes(ArrayList<TimeRange> unavailableTimes) {
 
    }
       

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -14,6 +14,8 @@
 
 package com.google.sps;
 
+import java.io.*; 
+import java.lang.*;
 import java.util.Collection;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -83,11 +85,11 @@ public final class FindMeetingQuery {
        LinkedList<TimeRange> mergedeventTimes = new LinkedList<>();
        for (TimeRange tr : eventTimes) {
            // Append current TimeRange if there's no overlap with the last TimeRange or no TimeRanges have been merged yet
-           if (mergedeventTimes.isEmpty() || mergedeventTimes.getLast().overlaps(tr)) {
+           if (mergedeventTimes.isEmpty() || !mergedeventTimes.getLast().overlaps(tr)) {
                mergedeventTimes.add(tr);
            }
 
-           // Merge current and previous TimeRange if overlap exists by updating the last TimeRange
+           // Merge current and previous TimeRange if overlap exists by updating the last TimeRange -- can we always be sure last time?
            else {
                TimeRange lastTime = mergedeventTimes.getLast();
 
@@ -138,16 +140,16 @@ public final class FindMeetingQuery {
             while (i != unavailableTimes.size() - 1){ // does this catch for only 2 elements aka size 2 yes it runs through once
                 TimeRange earlierTime = unavailableTimes.get(i);
                 TimeRange laterTime = unavailableTimes.get(i + 1);
-                
+
                 // If the duration between two events is long enough, then the attendees are available in between the events, excluding the start time of the second event
-                if (laterTime.start() - earlierTime.end() >= requestDuration)
+                if (laterTime.start() - earlierTime.end() >= (requestDuration))
                     availableTimes.add(TimeRange.fromStartEnd(earlierTime.end(), laterTime.start(), false));
 
                 i++;
             }    
 
             // If the last event does not end at the end of the day, create availability after the last event if there is enough time
-            if (unavailableTimes.getLast().end() != TimeRange.END_OF_DAY) {
+            if (unavailableTimes.getLast().end() - 1 != TimeRange.END_OF_DAY) {
                 if (TimeRange.END_OF_DAY - unavailableTimes.getLast().end() >= requestDuration)
                     availableTimes.add(TimeRange.fromStartEnd(unavailableTimes.getLast().end(), TimeRange.END_OF_DAY, true));
             }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -217,7 +217,6 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
-    System.out.println("this test");
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
         Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -219,7 +219,7 @@ public final class FindMeetingQueryTest {
   @Test
   public void optionalAttendeeHasTwoOverlaps() {
     // Have each mandatory attendee have different events, and a single optional attendee who has a single event
-    // We should see only wo options that work for all three attendees.
+    // We should see only two options that work for all three attendees.
     //
     // Events  :       |--A--|     |--B--|
     //         :             |--C--|
@@ -422,4 +422,3 @@ public final class FindMeetingQueryTest {
     Assert.assertEquals(expected, actual);
   }
 }
-

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -14,6 +14,8 @@
 
 package com.google.sps;
 
+import java.io.*; 
+import java.lang.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -215,7 +217,7 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
-
+    System.out.println("this test");
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
         Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -36,6 +36,7 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -113,6 +114,37 @@ public final class FindMeetingQueryTest {
 
     MeetingRequest request =
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeeIsNeverAvailable() {
+    // Have each mandatory atendee have different events, and a single optional attendee who has an 
+    // all day event. We should see two options because each person has
+    // split the restricted times.
+    //
+    // Events  :       |--A--|     |--B--|
+    //         : |-------------C---------------|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_C)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B, PERSON_C), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -69,10 +69,20 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
-  
+
   @Test
-  public void optionsForNoAttendees() {
+  public void noGapsForOnlyOptionalAttendees() {
+      
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TIME_0800AM, TIME_1100AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_B)));
+
+
     MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_1_HOUR);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(NO_EVENTS, request);
     Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -127,7 +127,7 @@ public final class FindMeetingQueryTest {
   @Test
   public void optionalAttendeeIsNeverAvailable() {
     // Have each mandatory atendee have different events, and a single optional attendee who has an 
-    // all day event. We should see two options because each person has
+    // all day event. We should see three options because each person has
     // split the restricted times.
     //
     // Events  :       |--A--|     |--B--|
@@ -150,6 +150,35 @@ public final class FindMeetingQueryTest {
     Collection<TimeRange> expected =
         Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeeHasTwoOverlaps() {
+    // Have each mandatory attendee have different events, and a single optional attendee who has a single event
+    // We should see only wo options that work for all three attendees.
+    //
+    // Events  :       |--A--|     |--B--|
+    //         :             |--C--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|                 |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            Arrays.asList(PERSON_C)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B, PERSON_C), DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);


### PR DESCRIPTION
Commits fe954c9 to 6b9a076

Wrote 5 new tests to allow users to request optional attendees in their meeting requests. If at least one potential meeting time is found where all optional and required attendees are available, then these meetings times will be displayed to the user. Otherwise, only meeting times where the required attendees are available will be displayed. 